### PR TITLE
feat: Upgrade tasks to the latest versions

### DIFF
--- a/nodejs-devfile-sample-test/COMPONENT-pull-request.yaml
+++ b/nodejs-devfile-sample-test/COMPONENT-pull-request.yaml
@@ -409,7 +409,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
         - name: kind
           value: task
         resolver: bundles

--- a/nodejs-devfile-sample-test/COMPONENT-push.yaml
+++ b/nodejs-devfile-sample-test/COMPONENT-push.yaml
@@ -406,7 +406,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:cce2dfcc5bd6e91ee54aacdadad523b013eeae5cdaa7f6a4624b8cbcc040f439
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Release pipelinerun failed on comforma policy violation due to that a task version is untrusted. So upgrade the task version to the latest one.