### PR TITLE
feat: parametrize quay-repo where out-image is pushed to

### DIFF
--- a/nodejs-devfile-sample-test/COMPONENT-pull-request.yaml
+++ b/nodejs-devfile-sample-test/COMPONENT-pull-request.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads-stage/NAMESPACE/COMPONENT:on-pr-{{revision}}
+    value: quay.io/QUAY_REPO/NAMESPACE/COMPONENT:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/nodejs-devfile-sample-test/COMPONENT-push.yaml
+++ b/nodejs-devfile-sample-test/COMPONENT-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads-stage/NAMESPACE/COMPONENT:{{revision}}
+    value: quay.io/QUAY_REPO/NAMESPACE/COMPONENT:{{revision}}
   - name: dockerfile
     value: /Dockerfile
   - name: build-source-image


### PR DESCRIPTION
The pipelinerun templates are used by the probe release tests in both Konflux stage and production environments, so the quay repo where out-image is pushed to should behave dynamically based on the environment.