### PR TITLE
Add the parameter `builds-platforms` to the stone-prd-rh01-RPM, kfluxfedorap01-RPM PipelineRuns

### DIFF
--- a/kfluxfedorap01-RPM/COMPONENT-pull-request.yaml
+++ b/kfluxfedorap01-RPM/COMPONENT-pull-request.yaml
@@ -29,6 +29,11 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/konflux-fedora/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
     - name: build-architectures
       value:
         - aarch64

--- a/kfluxfedorap01-RPM/COMPONENT-push.yaml
+++ b/kfluxfedorap01-RPM/COMPONENT-push.yaml
@@ -29,6 +29,11 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/konflux-fedora/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
     - name: build-architectures
       value:
         - aarch64

--- a/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
@@ -29,6 +29,11 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
     - name: build-architectures
       value:
         - aarch64

--- a/stone-prd-rh01-RPM/COMPONENT-push.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-push.yaml
@@ -29,6 +29,11 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
     - name: build-architectures
       value:
         - aarch64


### PR DESCRIPTION
Add the parameter `builds-platforms` to the stone-prd-rh01-RPM, kfluxfedorap01-RPM PipelineRuns. This will help ensure that the RPM probe jobs continue to run without errors once the changes related to the bug ‘MPC VMs created bypassing Kueue - KONFLUX-11978’ are released to production