### PR TITLE
Add the parameter build-platforms to the kflux-rhel-p01-RPM, stone-prod-p02-RPM PipelineRuns

### DIFF
--- a/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
@@ -18,6 +18,12 @@ metadata:
   namespace: NAMESPACE
 spec:
   params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
     - name: package-name
       value: libecpg
     - name: git-url

--- a/kflux-rhel-p01-RPM/COMPONENT-push.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-push.yaml
@@ -17,6 +17,12 @@ metadata:
   namespace: NAMESPACE
 spec:
   params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
     - name: package-name
       value: libecpg
     - name: git-url

--- a/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
@@ -18,6 +18,12 @@ metadata:
   namespace: NAMESPACE
 spec:
   params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
     - name: package-name
       value: libecpg
     - name: git-url

--- a/stone-prod-p02-RPM/COMPONENT-push.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-push.yaml
@@ -17,6 +17,12 @@ metadata:
   namespace: NAMESPACE
 spec:
   params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
     - name: package-name
       value: libecpg
     - name: git-url


### PR DESCRIPTION
Add the parameter build-platforms to the kflux-rhel-p01-RPM, stone-prod-p02-RPM PipelineRuns. This will help ensure that the RPM probe jobs continue to run without errors once the changes related to the bug ‘MPC VMs created bypassing Kueue - KONFLUX-11978’ are released to production