### PR TITLE
Pin Tekton git-resolver pipeline references to commit SHAs

### DIFF
--- a/kflux-fedora-01-RPM-TEST/COMPONENT-pull-request.yaml
+++ b/kflux-fedora-01-RPM-TEST/COMPONENT-pull-request.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "main"
+        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM-TEST/COMPONENT-pull-request.yaml
+++ b/kflux-fedora-01-RPM-TEST/COMPONENT-pull-request.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM-TEST/COMPONENT-push.yaml
+++ b/kflux-fedora-01-RPM-TEST/COMPONENT-push.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "main"
+        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM-TEST/COMPONENT-push.yaml
+++ b/kflux-fedora-01-RPM-TEST/COMPONENT-push.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM/COMPONENT-pull-request.yaml
+++ b/kflux-fedora-01-RPM/COMPONENT-pull-request.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "main"
+        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM/COMPONENT-pull-request.yaml
+++ b/kflux-fedora-01-RPM/COMPONENT-pull-request.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM/COMPONENT-push.yaml
+++ b/kflux-fedora-01-RPM/COMPONENT-push.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "main"
+        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-fedora-01-RPM/COMPONENT-push.yaml
+++ b/kflux-fedora-01-RPM/COMPONENT-push.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.com/fedora/infrastructure/konflux/rpmbuild-pipeline
       - name: revision
-        value: "c8a0bf7f6605239e7e2b3d8832c2627421ce0703"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM-TEST/COMPONENT-pull-request.yaml
+++ b/kflux-rhel-p01-RPM-TEST/COMPONENT-pull-request.yaml
@@ -34,13 +34,17 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM-TEST/COMPONENT-pull-request.yaml
+++ b/kflux-rhel-p01-RPM-TEST/COMPONENT-pull-request.yaml
@@ -37,14 +37,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM-TEST/COMPONENT-push.yaml
+++ b/kflux-rhel-p01-RPM-TEST/COMPONENT-push.yaml
@@ -33,13 +33,17 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM-TEST/COMPONENT-push.yaml
+++ b/kflux-rhel-p01-RPM-TEST/COMPONENT-push.yaml
@@ -36,14 +36,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
@@ -34,13 +34,17 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-pull-request.yaml
@@ -37,14 +37,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM/COMPONENT-push.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-push.yaml
@@ -33,13 +33,17 @@ spec:
       value: "{{ target_branch }}"
     - name: ociStorage
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/kflux-rhel-p01-RPM/COMPONENT-push.yaml
+++ b/kflux-rhel-p01-RPM/COMPONENT-push.yaml
@@ -36,14 +36,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
     - name: self-ref-revision
-      value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://github.com/konflux-ci/rpmbuild-pipeline.git
       - name: revision
-        value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-pull-request.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
+    - name: self-ref-revision
+      value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://github.com/konflux-ci/rpmbuild-pipeline.git
       - name: revision
-        value: "main"
+        value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prd-rh01-RPM/COMPONENT-push.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-push.yaml
@@ -43,14 +43,14 @@ spec:
     - name: self-ref-url
       value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
     - name: self-ref-revision
-      value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
+      value: "main"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://github.com/konflux-ci/rpmbuild-pipeline.git
       - name: revision
-        value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
+        value: "main"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prd-rh01-RPM/COMPONENT-push.yaml
+++ b/stone-prd-rh01-RPM/COMPONENT-push.yaml
@@ -40,13 +40,17 @@ spec:
         - x86_64
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
+    - name: self-ref-revision
+      value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://github.com/konflux-ci/rpmbuild-pipeline.git
       - name: revision
-        value: "main"
+        value: "47149d31753c0bf46cc9fe5dc50af3716aeea63c"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
@@ -36,13 +36,17 @@ spec:
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-pull-request.yaml
@@ -39,14 +39,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prod-p02-RPM/COMPONENT-push.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-push.yaml
@@ -35,13 +35,17 @@ spec:
       value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
     - name: strictArch
       value: "false"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 137f546f0acd1bc36023737b6dfbd266f923c529
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: main
+        value: 137f546f0acd1bc36023737b6dfbd266f923c529
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:

--- a/stone-prod-p02-RPM/COMPONENT-push.yaml
+++ b/stone-prod-p02-RPM/COMPONENT-push.yaml
@@ -38,14 +38,14 @@ spec:
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision
-      value: 137f546f0acd1bc36023737b6dfbd266f923c529
+      value: main
   pipelineRef:
     resolver: git
     params:
       - name: url
         value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
       - name: revision
-        value: 137f546f0acd1bc36023737b6dfbd266f923c529
+        value: main
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   taskRunTemplate:


### PR DESCRIPTION
Works with KONFLUX-14479. 

Setting up some hard-coded commit SHA values (the revision values) which will then be updated by a corresponding PR: https://gitlab.cee.redhat.com/redhat-performance/ci-configs/-/merge_requests/624