### PR TITLE
PVO11Y-5374 Add staging RPM template directories

### DIFF
--- a/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: '{{ source_url }}/-/tree/{{ revision }}'
+    build.appstudio.redhat.com/commit_sha: '{{ revision }}'
+    build.appstudio.redhat.com/pull_request_number: '{{ pull_request_number }}'
+    build.appstudio.redhat.com/target_branch: '{{ target_branch }}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-pull-request
+  namespace: NAMESPACE
+spec:
+  params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
+    - name: package-name
+      value: libecpg
+    - name: git-url
+      value: "{{ source_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: target-branch
+      value: "{{ target_branch }}"
+    - name: ociStorage
+      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 501161ea2a5824f8e9e33f90e990ce7cc5595b96
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/stone-stage-p01-RPM/COMPONENT-push.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-push.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: '{{ source_url }}/-/tree/{{ revision }}'
+    build.appstudio.redhat.com/commit_sha: '{{ revision }}'
+    build.appstudio.redhat.com/target_branch: '{{ target_branch }}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-push
+  namespace: NAMESPACE
+spec:
+  params:
+    - name: build-platforms
+      value:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
+    - name: package-name
+      value: libecpg
+    - name: git-url
+      value: "{{ source_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: target-branch
+      value: "{{ target_branch }}"
+    - name: ociStorage
+      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: self-ref-url
+      value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
+    - name: self-ref-revision
+      value: 501161ea2a5824f8e9e33f90e990ce7cc5595b96
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/stone-stg-rh01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-stg-rh01-RPM/COMPONENT-pull-request.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: '{{ source_url }}?rev={{ revision }}'
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-pull-request
+  namespace: NAMESPACE
+spec:
+  params:
+    - name: package-name
+      value: libecpg
+    - name: git-url
+      value: "{{ source_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: target-branch
+      value: "{{ target_branch }}"
+    - name: ociStorage
+      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
+    - name: build-architectures
+      value:
+        - aarch64
+        - x86_64
+    - name: strictArch
+      value: "false"
+    - name: self-ref-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
+    - name: self-ref-revision
+      value: 47149d31753c0bf46cc9fe5dc50af3716aeea63c
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/konflux-ci/rpmbuild-pipeline.git
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'

--- a/stone-stg-rh01-RPM/COMPONENT-push.yaml
+++ b/stone-stg-rh01-RPM/COMPONENT-push.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: '{{ source_url }}?rev={{ revision }}'
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-push
+  namespace: NAMESPACE
+spec:
+  params:
+    - name: package-name
+      value: libecpg
+    - name: git-url
+      value: "{{ source_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: target-branch
+      value: "{{ target_branch }}"
+    - name: ociStorage
+      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+    - name: build-platforms
+      value:
+        - localhost
+        - linux/amd64
+        - linux/arm64
+    - name: build-architectures
+      value:
+        - aarch64
+        - x86_64
+    - name: strictArch
+      value: "false"
+    - name: self-ref-url
+      value: "https://github.com/konflux-ci/rpmbuild-pipeline.git"
+    - name: self-ref-revision
+      value: 47149d31753c0bf46cc9fe5dc50af3716aeea63c
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/konflux-ci/rpmbuild-pipeline.git
+      - name: revision
+        value: "main"
+      - name: pathInRepo
+        value: pipeline/build-rpm-package.yaml
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## What

Add RPM PipelineRun template directories for staging kanary probe tests:
- `stone-stg-rh01-RPM/` — copied from `stone-prd-rh01-RPM/` (GitHub/public rpmbuild-pipeline family)
- `stone-stage-p01-RPM/` — copied from `kflux-rhel-p01-RPM/` (gitlab.cee rpmbuild-pipeline family)

Templates are cluster-agnostic (COMPONENT, revision, namespace are substituted at runtime by the loadtest binary), so these are straight copies from the corresponding production templates.

[PVO11Y-5374](https://issues.redhat.com/browse/PVO11Y-5374)

## Why

Prerequisite for enabling RPM kanary probes on staging clusters. The loadtest binary fetches templates from this repo and needs directories matching the `pipeline-repo-templating-source-dir` param in each cronjob.

## Validation

- Files match their production counterparts exactly