### PR TITLE
PVO11Y-5418 Fix ociStorage quay org for staging RPM templates

### DIFF
--- a/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: ociStorage
-      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+      value: "quay.io/redhat-user-workloads-stage/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision

--- a/stone-stage-p01-RPM/COMPONENT-push.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-push.yaml
@@ -32,7 +32,7 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: ociStorage
-      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+      value: "quay.io/redhat-user-workloads-stage/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
     - name: self-ref-url
       value: "https://gitlab.cee.redhat.com/rhel-on-konflux/rpmbuild-pipeline"
     - name: self-ref-revision

--- a/stone-stg-rh01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-stg-rh01-RPM/COMPONENT-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: ociStorage
-      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
+      value: "quay.io/redhat-user-workloads-stage/$(context.taskRun.namespace)/COMPONENT:on-pr-{{revision}}"
     - name: build-platforms
       value:
         - localhost

--- a/stone-stg-rh01-RPM/COMPONENT-push.yaml
+++ b/stone-stg-rh01-RPM/COMPONENT-push.yaml
@@ -28,7 +28,7 @@ spec:
     - name: target-branch
       value: "{{ target_branch }}"
     - name: ociStorage
-      value: "quay.io/redhat-user-workloads/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
+      value: "quay.io/redhat-user-workloads-stage/$(context.taskRun.namespace)/COMPONENT:$(params.revision)"
     - name: build-platforms
       value:
         - localhost


### PR DESCRIPTION
## What

Fix `ociStorage` param in all four staging RPM pipeline templates to use `redhat-user-workloads-stage` instead of `redhat-user-workloads`:

- `stone-stg-rh01-RPM/COMPONENT-push.yaml`
- `stone-stg-rh01-RPM/COMPONENT-pull-request.yaml`
- `stone-stage-p01-RPM/COMPONENT-push.yaml`
- `stone-stage-p01-RPM/COMPONENT-pull-request.yaml`

[PVO11Y-5418](https://redhat.atlassian.net/browse/PVO11Y-5418)

## Why

The staging RPM templates were copied from `stone-prd-rh01-RPM` which uses the production quay org. On staging clusters, the image-controller creates quay repos and credentials under `redhat-user-workloads-stage`, not `redhat-user-workloads`. This caused the `create-trusted-artifact` step in `clone-repository` to fail with `quay.io 401 Unauthorized` on every RPM kanary probe run on stone-stg-rh01 and stone-stage-p01.

Root cause confirmed by inspecting `components-namespace-pull` secret in `konflux-perfscale-4-tenant` on stone-stg-rh01 — it only grants access to `quay.io/redhat-user-workloads-stage/konflux-perfscale-4-tenant`.