### PR TITLE
PVO11Y-5418 Add kueue localhost annotation to stone-stage-p01-RPM templates

### DIFF
--- a/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-pull-request.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    kueue.konflux-ci.dev/requests-localhost: "true"
     build.appstudio.openshift.io/repo: '{{ source_url }}/-/tree/{{ revision }}'
     build.appstudio.redhat.com/commit_sha: '{{ revision }}'
     build.appstudio.redhat.com/pull_request_number: '{{ pull_request_number }}'

--- a/stone-stage-p01-RPM/COMPONENT-push.yaml
+++ b/stone-stage-p01-RPM/COMPONENT-push.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    kueue.konflux-ci.dev/requests-localhost: "true"
     build.appstudio.openshift.io/repo: '{{ source_url }}/-/tree/{{ revision }}'
     build.appstudio.redhat.com/commit_sha: '{{ revision }}'
     build.appstudio.redhat.com/target_branch: '{{ target_branch }}'


### PR DESCRIPTION
## What

Add `kueue.konflux-ci.dev/requests-localhost: "true"` annotation to both `stone-stage-p01-RPM/COMPONENT-push.yaml` and `stone-stage-p01-RPM/COMPONENT-pull-request.yaml`.

[PVO11Y-5418](https://redhat.atlassian.net/browse/PVO11Y-5418)

## Why

The `rhel-on-konflux/rpmbuild-pipeline` internally creates a `calculate-deps-i686` TaskRun with `PLATFORM=localhost`. stone-stage-p01 enforces a `ValidatingAdmissionPolicy` (`no-skip.kueue.konflux-ci.dev`) that blocks any TaskRun using `localhost` unless the parent PipelineRun carries the `kueue.konflux-ci.dev/requests-localhost` annotation. This caused every RPM kanary probe run on stone-stage-p01 to fail immediately with:

```
taskruns.tekton.dev "...-calculate-deps-i686" is forbidden:
ValidatingAdmissionPolicy 'no-skip.kueue.konflux-ci.dev' denied request:
TaskRun with PLATFORM param set to localhost must have the annotation
'kueue.konflux-ci.dev/requests-localhost'
```