### PR TITLE
Add Python wheel build probe templates using fromager

### DIFF
--- a/python-wheel-build/COMPONENT-pull-request.yaml
+++ b/python-wheel-build/COMPONENT-pull-request.yaml
@@ -1,0 +1,203 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: REPOURL?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-pull-request
+  namespace: NAMESPACE
+spec:
+  timeouts:
+    pipeline: "45m"
+  params:
+  - name: packages
+    value:
+    - "urllib3==2.5.0"
+  - name: output-image
+    # Push to rhtap-perf-test org, not redhat-user-workloads
+    # The robot account rhtap-perf-test+oci_storage_robot_stage only has write access to repos in the rhtap-perf-test org
+    value: quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage:python-wheel-COMPONENT-on-pr-{{revision}}
+  - name: image-expires-after
+    value: "5d"
+  pipelineSpec:
+    description: |
+      Build Python wheels from source using Fromager and push as an OCI artifact.
+      Uses the Calunga plumbing builder image to resolve dependencies and compile
+      wheels hermetically. Task specs inlined from:
+        https://github.com/calungaproject/plumbing/blob/main/tasks/build-python-wheels-oci-ta.yaml
+      The use-trusted-artifact step is omitted (not needed for builds without
+      fromager overrides). The bundle resolver on IBM Cloud cannot authenticate
+      to the private quay.io/konflux-ci/tekton-catalog/ bundles.
+    params:
+    - description: List of pinned Python packages to build
+      name: packages
+      type: array
+    - description: Fully Qualified Output Image for the OCI artifact
+      name: output-image
+      type: string
+    - default: ""
+      description: Image tag expiration time (e.g. 1h, 2d, 3w)
+      name: image-expires-after
+      type: string
+    results:
+    - description: OCI artifact URL
+      name: IMAGE_URL
+      value: $(tasks.build-python-wheels.results.IMAGE_URL)
+    - description: OCI artifact digest
+      name: IMAGE_DIGEST
+      value: $(tasks.build-python-wheels.results.IMAGE_DIGEST)
+    - description: OCI artifact reference
+      name: IMAGE_REF
+      value: $(tasks.build-python-wheels.results.IMAGE_REF)
+    tasks:
+    - name: build-python-wheels
+      params:
+      - name: PACKAGES
+        value:
+        - $(params.packages[*])
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      # Inlined from https://github.com/calungaproject/plumbing/blob/main/tasks/build-python-wheels-oci-ta.yaml
+      # Omits step 1 (use-trusted-artifact) — not needed for simple builds without fromager overrides.
+      # Steps 2-4 (build-wheels, collect-build-files, create-oci-artifact) are preserved as-is.
+      taskSpec:
+        params:
+        - name: PACKAGES
+          type: array
+        - name: IMAGE
+          type: string
+        - name: IMAGE_EXPIRES_AFTER
+          type: string
+          default: ""
+        results:
+        - name: IMAGE_DIGEST
+          description: Digest of the OCI artifact
+        - name: IMAGE_URL
+          description: OCI artifact repository and tag
+        - name: IMAGE_REF
+          description: OCI artifact reference
+        volumes:
+        - name: workdir
+          emptyDir: {}
+        - name: quay-auth
+          secret:
+            secretName: quay-push-secret
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+        stepTemplate:
+          computeResources:
+            limits:
+              cpu: "4"
+              memory: 4Gi
+            requests:
+              cpu: "4"
+              memory: 4Gi
+          volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+        steps:
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 2: build-wheels)
+        - name: build-wheels
+          image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-builder@sha256:d0ed5c94153b4b6db0b39aa330747dc167e1e4ad98fe3dab844798dd06f586d9
+          workingDir: /var/workdir
+          args:
+          - --
+          - $(params.PACKAGES[*])
+          script: |
+            #!/bin/bash
+            set -euo pipefail
+            PACKAGE_ARGS=()
+            in_packages=false
+            for arg in "$@"; do
+              if [ "$arg" = "--" ]; then
+                in_packages=true
+                continue
+              fi
+              if [[ "$in_packages" == "true" ]]; then
+                PACKAGE_ARGS+=("$arg")
+              fi
+            done
+            echo "[$(date --utc -Ins)] Building wheels for: ${PACKAGE_ARGS[*]}"
+            exec build-wheels "${PACKAGE_ARGS[@]}"
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 3: collect-build-files)
+        - name: collect-build-files
+          image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-builder@sha256:d0ed5c94153b4b6db0b39aa330747dc167e1e4ad98fe3dab844798dd06f586d9
+          command:
+          - collect-build-files
+          args:
+          - /var/workdir/output
+          - /var/workdir/artifact
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 4: create-oci-artifact)
+        - name: create-oci-artifact
+          image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+          workingDir: /var/workdir
+          env:
+          - name: IMAGE
+            value: $(params.IMAGE)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.IMAGE_EXPIRES_AFTER)
+          - name: DOCKER_CONFIG
+            value: /var/run/quay-auth
+          volumeMounts:
+          - name: quay-auth
+            mountPath: /var/run/quay-auth
+            readOnly: true
+          script: |
+            #!/bin/bash
+            set -euo pipefail
+            echo "[$(date --utc -Ins)] Pushing OCI artifact"
+
+            # Try select-oci-auth first, fall back to mounted secret
+            if select-oci-auth "$IMAGE" > auth.json 2>/dev/null && [ -s auth.json ]; then
+              echo "Using select-oci-auth credentials"
+            else
+              echo "Falling back to mounted quay-push-secret"
+              cp /var/run/quay-auth/config.json auth.json
+            fi
+            AUTHFILE="$(realpath auth.json)"
+            EXPIRE_LABEL=()
+            [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+            cd artifact
+            echo "Pushing OCI artifact to ${IMAGE}"
+            if ! retry oras push "$IMAGE" \
+              --registry-config "${AUTHFILE}" \
+              "${EXPIRE_LABEL[@]}" \
+              --artifact-type "application/vnd.python.wheels" \
+              *
+            then
+              echo "Failed to push OCI artifact ${IMAGE} to registry"
+              exit 1
+            fi
+            if ! RESULTING_DIGEST=$(retry oras resolve \
+              --registry-config "${AUTHFILE}" "${IMAGE}")
+            then
+              echo "Failed to get digest for ${IMAGE} from registry"
+              exit 1
+            fi
+            echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+            echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+            echo -n "${IMAGE}@${RESULTING_DIGEST}" | tee "$(results.IMAGE_REF.path)"
+            echo "[$(date --utc -Ins)] End create-oci-artifact"
+          computeResources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: "1"
+              memory: 1Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+status: {}

--- a/python-wheel-build/COMPONENT-push.yaml
+++ b/python-wheel-build/COMPONENT-push.yaml
@@ -1,0 +1,202 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: REPOURL?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: APPLICATION
+    appstudio.openshift.io/component: COMPONENT
+    pipelines.appstudio.openshift.io/type: build
+  name: COMPONENT-on-push
+  namespace: NAMESPACE
+spec:
+  timeouts:
+    pipeline: "45m"
+  params:
+  - name: packages
+    value:
+    - "urllib3==2.5.0"
+  - name: output-image
+    # Push to rhtap-perf-test org, not redhat-user-workloads
+    # The robot account rhtap-perf-test+oci_storage_robot_stage only has write access to repos in the rhtap-perf-test org
+    value: quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage:python-wheel-COMPONENT-{{revision}}
+  - name: image-expires-after
+    value: "7d"
+  pipelineSpec:
+    description: |
+      Build Python wheels from source using Fromager and push as an OCI artifact.
+      Uses the Calunga plumbing builder image to resolve dependencies and compile
+      wheels hermetically. Task specs inlined from:
+        https://github.com/calungaproject/plumbing/blob/main/tasks/build-python-wheels-oci-ta.yaml
+      The use-trusted-artifact step is omitted (not needed for builds without
+      fromager overrides). The bundle resolver on IBM Cloud cannot authenticate
+      to the private quay.io/konflux-ci/tekton-catalog/ bundles.
+    params:
+    - description: List of pinned Python packages to build
+      name: packages
+      type: array
+    - description: Fully Qualified Output Image for the OCI artifact
+      name: output-image
+      type: string
+    - default: ""
+      description: Image tag expiration time (e.g. 1h, 2d, 3w)
+      name: image-expires-after
+      type: string
+    results:
+    - description: OCI artifact URL
+      name: IMAGE_URL
+      value: $(tasks.build-python-wheels.results.IMAGE_URL)
+    - description: OCI artifact digest
+      name: IMAGE_DIGEST
+      value: $(tasks.build-python-wheels.results.IMAGE_DIGEST)
+    - description: OCI artifact reference
+      name: IMAGE_REF
+      value: $(tasks.build-python-wheels.results.IMAGE_REF)
+    tasks:
+    - name: build-python-wheels
+      params:
+      - name: PACKAGES
+        value:
+        - $(params.packages[*])
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      # Inlined from https://github.com/calungaproject/plumbing/blob/main/tasks/build-python-wheels-oci-ta.yaml
+      # Omits step 1 (use-trusted-artifact) — not needed for simple builds without fromager overrides.
+      # Steps 2-4 (build-wheels, collect-build-files, create-oci-artifact) are preserved as-is.
+      taskSpec:
+        params:
+        - name: PACKAGES
+          type: array
+        - name: IMAGE
+          type: string
+        - name: IMAGE_EXPIRES_AFTER
+          type: string
+          default: ""
+        results:
+        - name: IMAGE_DIGEST
+          description: Digest of the OCI artifact
+        - name: IMAGE_URL
+          description: OCI artifact repository and tag
+        - name: IMAGE_REF
+          description: OCI artifact reference
+        volumes:
+        - name: workdir
+          emptyDir: {}
+        - name: quay-auth
+          secret:
+            secretName: quay-push-secret
+            items:
+            - key: .dockerconfigjson
+              path: config.json
+        stepTemplate:
+          computeResources:
+            limits:
+              cpu: "4"
+              memory: 4Gi
+            requests:
+              cpu: "4"
+              memory: 4Gi
+          volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+        steps:
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 2: build-wheels)
+        - name: build-wheels
+          image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-builder@sha256:d0ed5c94153b4b6db0b39aa330747dc167e1e4ad98fe3dab844798dd06f586d9
+          workingDir: /var/workdir
+          args:
+          - --
+          - $(params.PACKAGES[*])
+          script: |
+            #!/bin/bash
+            set -euo pipefail
+            PACKAGE_ARGS=()
+            in_packages=false
+            for arg in "$@"; do
+              if [ "$arg" = "--" ]; then
+                in_packages=true
+                continue
+              fi
+              if [[ "$in_packages" == "true" ]]; then
+                PACKAGE_ARGS+=("$arg")
+              fi
+            done
+            echo "[$(date --utc -Ins)] Building wheels for: ${PACKAGE_ARGS[*]}"
+            exec build-wheels "${PACKAGE_ARGS[@]}"
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 3: collect-build-files)
+        - name: collect-build-files
+          image: quay.io/redhat-user-workloads/calunga-tenant/plumbing-builder@sha256:d0ed5c94153b4b6db0b39aa330747dc167e1e4ad98fe3dab844798dd06f586d9
+          command:
+          - collect-build-files
+          args:
+          - /var/workdir/output
+          - /var/workdir/artifact
+        # Step from plumbing tasks/build-python-wheels-oci-ta.yaml (step 4: create-oci-artifact)
+        - name: create-oci-artifact
+          image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+          workingDir: /var/workdir
+          env:
+          - name: IMAGE
+            value: $(params.IMAGE)
+          - name: IMAGE_EXPIRES_AFTER
+            value: $(params.IMAGE_EXPIRES_AFTER)
+          - name: DOCKER_CONFIG
+            value: /var/run/quay-auth
+          volumeMounts:
+          - name: quay-auth
+            mountPath: /var/run/quay-auth
+            readOnly: true
+          script: |
+            #!/bin/bash
+            set -euo pipefail
+            echo "[$(date --utc -Ins)] Pushing OCI artifact"
+
+            # Try select-oci-auth first, fall back to mounted secret
+            if select-oci-auth "$IMAGE" > auth.json 2>/dev/null && [ -s auth.json ]; then
+              echo "Using select-oci-auth credentials"
+            else
+              echo "Falling back to mounted quay-push-secret"
+              cp /var/run/quay-auth/config.json auth.json
+            fi
+            AUTHFILE="$(realpath auth.json)"
+            EXPIRE_LABEL=()
+            [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+            cd artifact
+            echo "Pushing OCI artifact to ${IMAGE}"
+            if ! retry oras push "$IMAGE" \
+              --registry-config "${AUTHFILE}" \
+              "${EXPIRE_LABEL[@]}" \
+              --artifact-type "application/vnd.python.wheels" \
+              *
+            then
+              echo "Failed to push OCI artifact ${IMAGE} to registry"
+              exit 1
+            fi
+            if ! RESULTING_DIGEST=$(retry oras resolve \
+              --registry-config "${AUTHFILE}" "${IMAGE}")
+            then
+              echo "Failed to get digest for ${IMAGE} from registry"
+              exit 1
+            fi
+            echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+            echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+            echo -n "${IMAGE}@${RESULTING_DIGEST}" | tee "$(results.IMAGE_REF.path)"
+            echo "[$(date --utc -Ins)] End create-oci-artifact"
+          computeResources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: "1"
+              memory: 1Gi
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-COMPONENT
+status: {}


### PR DESCRIPTION
Inlined task specs from calungaproject/plumbing build-python-wheels-oci-ta task. Bundle refs are private and the bundle resolver on IBM Cloud times out, so all steps are embedded directly.

Tested on lightwell-dev cluster: urllib3==2.5.0 builds successfully with all 14 dependencies and pushes OCI artifact to quay.io.

Ref: KONFLUX-15401

Assisted-by: Claude Code (Anthropic)